### PR TITLE
Preserve symbolic links when copying files via `cp`.

### DIFF
--- a/100-prerun.sh
+++ b/100-prerun.sh
@@ -22,7 +22,7 @@ if [[ ! -f $done_file ]]; then
         echo "xxh-plugin-prerun-dotfiles: Create file $target_item"
       fi
       mkdir -p $target_dir
-      cp $item $target_item
+      cp -R $item $target_item
     elif [[ -d $item && ! -d $target_item ]]; then
       if [[ $XXH_VERBOSE == '1' || $XXH_VERBOSE == '2' ]]; then
         echo "xxh-plugin-prerun-dotfiles: Create dir $target_item"

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ rm -rf $build_dir && mkdir -p $build_dir
 
 for f in *prerun.sh home
 do
-    cp -r $CDIR/$f $build_dir/
+    cp -R $CDIR/$f $build_dir/
 done
 
 if [ -x "$(command -v pip)" ]; then


### PR DESCRIPTION
On GNU/Linux cp -r and cp -R behind identically, and symbolic links are preserved.

However, on macOS they behave differently: cp -r will copy the indirected symbolic link (i.e the content is copied, resulting in a regular file).

This patch changes all occurrences of cp -r with cp -R.

Tested on:

macOS 12.6 (Monterey)
Ubuntu 18.04 LTS
Ubuntu 22.04 LTS
